### PR TITLE
isNumber should return false for NaN

### DIFF
--- a/transducers.js
+++ b/transducers.js
@@ -100,7 +100,7 @@ function isObject(x) {
 }
 
 function isNumber(x) {
-  return typeof x === 'number';
+  return typeof x === 'number' && x === x;
 }
 
 function Reduced(value) {


### PR DESCRIPTION
unfortunately, `typeof NaN` is `number`. I think that is not the behavior you want. This little patch fixes that.