### PR TITLE
Remove unused getReducer function

### DIFF
--- a/transducers.js
+++ b/transducers.js
@@ -680,19 +680,6 @@ var objReducer = {
   step: merge
 };
 
-function getReducer(coll) {
-  if(isArray(coll)) {
-    return arrayReducer;
-  }
-  else if(isObject(coll)) {
-    return objReducer;
-  }
-  else if(fulfillsProtocol(coll, 'transformer')) {
-    return getProtocolProperty(coll, 'transformer');
-  }
-  throwProtocolError('getReducer', coll);
-}
-
 // building new collections
 
 function toArray(coll, xform) {


### PR DESCRIPTION
Not sure if this was an artifact from a previous version, or something intended to be used but wasn't.