### PR TITLE
fix application of compose helper doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ var transform = compose(
 );
 ```
 
-`compose` is a provided function that simply turns `compose(f, g)` into `x => f(g(x))`. You use it to build up transformations. The above transformation would always run the map and filter **only twice** becaue only two items are needed, and it short-circuits once it gets two items. Again, this is done without laziness, read more [here](http://jlongster.com/Transducers.js--A-JavaScript-Library-for-Transformation-of-Data).
+`compose` is a provided function that simply turns `compose(f, g)` into `x => g(f(x))`. You use it to build up transformations. The above transformation would always run the map and filter **only twice** becaue only two items are needed, and it short-circuits once it gets two items. Again, this is done without laziness, read more [here](http://jlongster.com/Transducers.js--A-JavaScript-Library-for-Transformation-of-Data).
 
 There are also 2 transducers available for taking collections and "catting" them into the transformation stream:
 


### PR DESCRIPTION
```
> var transform = t.compose(t.map(function (x) { return [x.length] }), t.cat)
undefined
> t.seq([[1,2,3], [34,5], [2,3,4,4]], transform)
[ 3, 2, 4 ]
```
compose(f, g) //=> g(f(x)) Is this the intended behaviour or should it be the other way ?