### PR TITLE
Added self-returning Symbol.iterator/@@iterator method to iterators

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -424,7 +424,10 @@ describe('', () => {
       },
     };
 
+    var protocol = typeof Symbol !== 'undefined' ? Symbol.iterator : '@@iterator';
     var lt = toIter(nums, map(x => x * 2));
+
+    expect(lt[protocol]()).to.equal(lt);
     expect(lt instanceof t.LazyTransformer).to.be.ok();
     expect(toArray(lt, take(5)),
            [0, 2, 4, 6, 8]);


### PR DESCRIPTION
closes #37 
1. Adds self-returning `protocols.iterator` method to created iterators
2. For consistency, wraps malformed iterators with same
3. Updates the iterator test to check for `iter[protocol]() === iter`
