### PR TITLE
Fix iterator protocol support + npm build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ var transform = compose(
 );
 ```
 
-`compose` is a provided function that simply turns `compose(f, g)` into `x => f(g(x))`. You use it to build up transformations. The above transformation would always run the map and filter **only twice** because only two items are needed, and it short-circuits once it gets two items. Again, this is done without laziness, read more [here](http://jlongster.com/Transducers.js--A-JavaScript-Library-for-Transformation-of-Data).
+`compose` is a provided function that simply turns `compose(f, g)` into `x => f(g(x))`. You use it to build up transformations. The above transformation would always run the map and filter **only twice** becaue only two items are needed, and it short-circuits once it gets two items. Again, this is done without laziness, read more [here](http://jlongster.com/Transducers.js--A-JavaScript-Library-for-Transformation-of-Data).
 
 There are also 2 transducers available for taking collections and "catting" them into the transformation stream:
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "author": "James Long <longster@gmail.com>",
   "main": "./transducers.js",
   "scripts": {
-    "test": "mocha ./tests/tests.js"
+    "test": "mocha ./tests/tests.js",
+    "build": "webpack",
+    "build:uglify": "NODE_ENV=production webpack"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.3.2",
   "author": "James Long <longster@gmail.com>",
   "main": "./transducers.js",
+  "scripts": {
+    "test": "mocha ./tests/tests.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/jlongster/transducers.js.git"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "mocha ./tests/tests.js",
     "build": "webpack",
-    "build:uglify": "NODE_ENV=production webpack"
+    "build:uglify": "NODE_ENV=production webpack",
+    "prepublish": "npm -s run build && npm test"
   },
   "repository": {
     "type": "git",

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,7 +1,7 @@
 var expect = require('expect.js');
 var Immutable = require('immutable');
 var t = require('../transducers');
-var { reduce, transformer, toArray, toObj, toIter, iterate, push, merge, empty,
+var { reduce, transformer, toArray, toObj, toIter, iterator, push, merge, empty,
       transduce, seq, into, compose, map, filter, remove,
       cat, mapcat, keep, dedupe, take, takeWhile,
       drop, dropWhile, partition, partitionBy,
@@ -9,6 +9,7 @@ var { reduce, transformer, toArray, toObj, toIter, iterate, push, merge, empty,
 
 var context = { num: 5 };
 
+var iterProtocol = Symbol && typeof Symbol.iterator !== 'undefined' ? Symbol.iterator : '@@iterator';
 // utility
 
 function first(x) {
@@ -413,7 +414,7 @@ describe('', () => {
         { foo: 2, bar: 3 });
   });
 
-  it('iter should work', function() {
+  it('toIter should work', function() {
     var nums = {
       i: 0,
       next: function() {
@@ -425,8 +426,39 @@ describe('', () => {
     };
 
     var lt = toIter(nums, map(x => x * 2));
+
+    expect(lt[iterProtocol]()).to.equal(lt);
     expect(lt instanceof t.LazyTransformer).to.be.ok();
     expect(toArray(lt, take(5)),
            [0, 2, 4, 6, 8]);
+
+    var iter = toIter(nums);
+    expect(iter[iterProtocol]()).to.equal(iter);
+    expect(toArray(iter, take(5)), 
+      [0, 1, 2, 3, 4]);
+  });
+
+  it('iterator should work', function() {
+    var obj = {a: 1, b: 2, c: 3};
+    var nums = [1, 2, 3];
+    var broken = {
+      i: 1,
+      next: function() {
+        return {
+          value: this.i++,
+          done: this.i <= 3
+        }
+      }
+    };
+
+    var [objIter, numsIter, brokenIter] = [obj, nums, broken].map(iterator);
+
+    expect(objIter[iterProtocol](), objIter);
+    expect(numsIter[iterProtocol](), numsIter);
+    expect(brokenIter[iterProtocol](), brokenIter);
+
+    expect(toObj(objIter), {a: 1, b: 2, c: 3});
+    expect(toArray(numsIter), [1, 2, 3]);
+    expect(toArray(brokenIter), [1, 2, 3]);
   });
 });

--- a/transducers.js
+++ b/transducers.js
@@ -61,7 +61,6 @@ function ArrayIterator(arr) {
   this.index = 0;
 }
 
-
 ArrayIterator.prototype.next = function() {
   if(this.index < this.arr.length) {
     return {


### PR DESCRIPTION
closes #37
replaces #38 

Ensured that the `.iterator` and `.toIter` methods are compliant with iterator-protocol by adding a self-returning `Symbol.iterator`/`@@iterator` method to all returned iterators, rather than just those produced by `LazyTransformer`. Also added some additional tests to make sure it checks iterators produced from `LazyTransformer` *and* `WrappedIterator`.

I noticed that `dist/transducers.js` was already out of date compared to the source code, so I had also added some build and test scripts, as well as a `prepublish` script to ensure dist is built before it's published. Let me know if you'd rather that go in a separate PR and I'll gladly remove them, but I figured it would help keep things in sync between the module/global versions. I didn't check in a new version of `dist/transducers.js`, though.